### PR TITLE
Color boards no longer working - updating the svg-based boards to work with lichess changes.

### DIFF
--- a/options.js
+++ b/options.js
@@ -17,8 +17,8 @@ const saveOptions = () => {
 
 
 
-        svgs = ["blue", "brown", "green", "ic", "purple", "pink"]
-        pngs = ["pink-pyramid", "purple-diag", "newspaper", "green-plastic", "ncf-board"]
+        svgs = []
+        pngs = ["blue", "brown", "green", "ic", "purple", "pink", "pink-pyramid", "purple-diag", "newspaper", "green-plastic", "ncf-board"]
         if (svgs.includes(boardTheme.value)) {   
             board.style.backgroundImage = `url("https://raw.githubusercontent.com/lichess-org/lila/master/public/images/board/svg/${boardTheme.value}.svg")`;
         } else if (pngs.includes(boardTheme.value)) {
@@ -43,8 +43,8 @@ const saveOptions = () => {
             document.getElementById(pieceName).style.backgroundImage = `url("https://raw.githubusercontent.com/lichess-org/lila/master/public/piece/${pieceTheme.value}/${pieceLichessNames[index]}.svg")`;
         });
 
-        svgs = ["blue", "brown", "green", "ic", "purple", "pink"]
-        pngs = ["pink-pyramid", "purple-diag", "newspaper", "green-plastic", "ncf-board"]
+        svgs = []
+        pngs = ["blue", "brown", "green", "ic", "purple", "pink", "pink-pyramid", "purple-diag", "newspaper", "green-plastic", "ncf-board"]
         if (svgs.includes(items.boardTheme)) {   
             document.getElementById('board').style.backgroundImage = `url("https://raw.githubusercontent.com/lichess-org/lila/master/public/images/board/svg/${items.boardTheme}.svg")`;
         } else if (pngs.includes(items.boardTheme)) {

--- a/script.js
+++ b/script.js
@@ -52,8 +52,8 @@ if (window.location.href.includes("https://www.chess.com"))
       `);
 
         if (board == "none") return;
-        svgs = ["blue", "brown", "green", "ic", "purple"]
-        pngs = ["pink-pyramid", "purple-diag", "newspaper", "green-plastic", "ncf-board"]
+        svgs = []
+        pngs = ["blue", "brown", "green", "ic", "purple", "pink-pyramid", "purple-diag", "newspaper", "green-plastic", "ncf-board"]
         if (svgs.includes(board)) {
             addStyle(`
             .board, .fade-in-overlay {


### PR DESCRIPTION
The colored boards (blue, brown, green, ic, and purple) stopped working. They moved all the boards to be png-based now, no more svg. I left the old svg code in just in case we ever need it again. 

Here is the lichess change that broke things:

https://github.com/lichess-org/lila/pull/16468